### PR TITLE
Support for connecting to a remote varnish instance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,5 @@ tmp
 _yardoc
 doc/
 config/dev.yml
-
+.DS_Store
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@
 4. Copy `config/template_newrelic_plugin.yml` to `config/newrelic_plugin.yml`
 5. Edit `config/newrelic_plugin.yml` and replace "YOUR_LICENSE_KEY_HERE" with your New Relic license key
 6. Edit the `config/newrelic_plugin.yml` if you are running Varnish
-   with an -n argument
+   with an -n argument or if you want to connect to a remote instance
 7. Execute `./newrelic_varnish_plugin`
 8. Go back to the Extensions list and after a brief period you will see an entry for your extension
+
+## Connecting to a remote instance
+
+The connection is done by executing varnishstat remotely via ssh, so be sure to add the public key of the user running the process 
+in the authorized_keys file usually located in `/home/[user]/.ssh/authorized_keys` in the remote server for the configured user.

--- a/config/template_newrelic_plugin.yml
+++ b/config/template_newrelic_plugin.yml
@@ -33,6 +33,8 @@ agents:
   varnish:
     # Define one or more agents for each varnish instance
     -
-      name: "Local Varnish"
+      name: "Varnish 1"
       # -n argument for Varnish
-      vname:
+      # vname:
+      # host if you want to connect to a remote varnish
+      # host: user@hostname

--- a/newrelic_varnish_plugin
+++ b/newrelic_varnish_plugin
@@ -69,8 +69,12 @@ module VarnishAgent
     }
   end
 
-  def VarnishAgent.varnishstat(vname = nil)
-    cmd = [ "varnishstat", "-1", "-x" ]
+  def VarnishAgent.varnishstat(host = nil, vname = nil)
+    cmd = [ ]
+    if not host.nil?
+      cmd.push("ssh", "-t", "#{host}" )
+    end
+    cmd.push("varnishstat", "-1", "-x")
     if not vname.nil?
       cmd.push("-n", vname.to_s)
     end
@@ -92,6 +96,7 @@ module VarnishAgent
     agent_version '0.0.4'
     agent_human_labels("Varnish") { "#{@name||"varnish"}[#{@vname||"default"}]"}
     agent_config_options :vname
+    agent_config_options :host
 
 #    metric_human_label { "Varnish[#{agent.instance_label}]: #{config[:description]}" }
 
@@ -141,7 +146,7 @@ module VarnishAgent
     end
 
     def poll_cycle
-      stats = VarnishAgent.varnishstat(@vname)
+      stats = VarnishAgent.varnishstat(@host,@vname)
       VarnishAgent.groups.each do |gname, group|
         group["metrics"].each do |metric|
           stat = stats[metric]


### PR DESCRIPTION
I have a cluster of varnish instances and I wanted to install the plugin only in one server, so I modified the plugin slightly to allow it to connect to a remote server and execute varnishstat via ssh.

You need to have the necessary permissions in the remote server to be able to connect.
