### PR TITLE
Add the units for sm_balloc

### DIFF
--- a/newrelic_varnish_plugin
+++ b/newrelic_varnish_plugin
@@ -119,7 +119,7 @@ module VarnishAgent
         "sessions"
         when /^s_(req|pipe|pass|fetch)/
         "requests"
-        when /bytes$/
+        when /(bytes|balloc)$/
         "bytes"
         when /g_space$/
         "bytes"


### PR DESCRIPTION
I've just added the units for the sm_balloc variable, to stop the script from outputting a warning.

This should fix issue varnish/newrelic_varnish_plugin#7
