### PR TITLE
Allow ruby to be found in environment

### DIFF
--- a/newrelic_varnish_plugin
+++ b/newrelic_varnish_plugin
@@ -1,4 +1,4 @@
-#! /usr/bin/ruby
+#! /usr/bin/env ruby
 
 #
 # Copyright 2012 Varnish Software AS


### PR DESCRIPTION
Fixes a problem of starting the daemon on SmartOs.  My ruby is located under `/opt/local/bin`.
Could be considered a general improvement for cross platform friendliness.
