### PR TITLE
Added missing name variable from agent config options

### DIFF
--- a/newrelic_varnish_plugin
+++ b/newrelic_varnish_plugin
@@ -91,7 +91,7 @@ module VarnishAgent
     agent_guid "com.varnish-software.newrelic-stat"
     agent_version '0.0.5'
     agent_human_labels("Varnish") { "#{@name||"varnish"}[#{@vname||"default"}]"}
-    agent_config_options :vname
+    agent_config_options :name, :vname
 
 #    metric_human_label { "Varnish[#{agent.instance_label}]: #{config[:description]}" }
 


### PR DESCRIPTION
The instance agent variable 'name' wasn't being passed to the Ruby New Relic Agent, so any attempt to set the Varnish label would silently fail and revert back to "varnish[default]".

The attached commit fixes that and has been tested and confirmed working, hope this helps someone else :+1: 
